### PR TITLE
fix: Update branch protection status checks to match workflow job names

### DIFF
--- a/infrastructure/github/Pulumi.dev.yaml
+++ b/infrastructure/github/Pulumi.dev.yaml
@@ -13,6 +13,5 @@ config:
   github-management:require_up_to_date: "true"
   github-management:enforce_admins: "true"
   github-management:status_check_contexts:
-    - "ci/quality-checks"
-    - "ci/tests"
+    - "Code Quality and Tests"
   github-management:delete_branch_on_merge: "true"


### PR DESCRIPTION
## Summary
Fixes the mismatch between required status checks in branch protection and actual GitHub Actions workflow job names, resolving auto-merge blocking issues.

## Problem
The branch protection was configured with required status checks that don't exist:
- ❌  (doesn't exist)
- ❌  (doesn't exist)

This caused PRs to never auto-merge because GitHub was waiting for status checks that would never complete.

## Solution
Updated Pulumi configuration to use the actual workflow job name:
- ✅  (matches  job)

## Changes
- **File**: 
- **Change**: Updated  to match actual job names
- **Deployment**: Pulumi update applied to GitHub branch protection

## Test Plan
- [x] Updated Pulumi configuration 
- [x] Deployed changes via 
- [ ] Verify this PR auto-merges without admin override
- [ ] Confirm no manual intervention required

## Expected Result
This PR should automatically merge after CI passes, demonstrating that the branch protection fix works correctly.

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)