### PR TITLE
fix: Remove duplicate CI workflow runs caused by pull_request_target trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  pull_request_target:
-    branches: [ "main" ]
 
 jobs:
   formatting:
@@ -110,7 +108,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.actor == 'davidasnider'
+    if: github.event_name == 'pull_request' && github.actor == 'davidasnider'
     steps:
       - name: Auto approve PR
         uses: hmarr/auto-approve-action@v4
@@ -125,7 +123,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.actor == 'davidasnider'
+    if: github.event_name == 'pull_request' && github.actor == 'davidasnider'
     steps:
       - name: Enable auto-merge for PR
         uses: peter-evans/enable-pull-request-automerge@v3


### PR DESCRIPTION
## Summary
- Remove `pull_request_target` trigger from CI workflow to eliminate duplicate runs
- Update conditional logic in auto-approve and auto-merge jobs to match
- Maintains all functionality while reducing unnecessary workflow executions

## Changes
- Removed `pull_request_target` trigger from `.github/workflows/ci.yml`
- Updated job conditions to only check for `pull_request` events
- No functional changes to CI behavior

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Confirm single workflow run per PR (will be validated on this PR)

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)