### PR TITLE
fix: Enable CI workflows for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: github.event_name == 'pull_request' && github.actor == 'davidasnider'
+    if: github.event_name == 'pull_request' && (github.actor == 'davidasnider' || github.actor == 'dependabot[bot]')
     steps:
       - name: Auto approve PR
         uses: hmarr/auto-approve-action@v4
@@ -123,7 +123,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: github.event_name == 'pull_request' && github.actor == 'davidasnider'
+    if: github.event_name == 'pull_request' && (github.actor == 'davidasnider' || github.actor == 'dependabot[bot]')
     steps:
       - name: Enable auto-merge for PR
         uses: peter-evans/enable-pull-request-automerge@v3


### PR DESCRIPTION
## Summary
- Fixes CI workflow conditions to allow Dependabot PRs to run auto-approval and auto-merge
- Ensures automated dependency updates get proper testing and validation

## Problem
After enabling Dependabot in #19, the CI workflows were not running properly for Dependabot PRs because the auto-approve and auto-merge jobs were restricted to only `github.actor == 'davidasnider'`.

## Solution
Updated the workflow conditions in `.github/workflows/ci.yml` to include `dependabot[bot]`:

**Before:**
```yaml
if: github.event_name == 'pull_request' && github.actor == 'davidasnider'
```

**After:**
```yaml
if: github.event_name == 'pull_request' && (github.actor == 'davidasnider' || github.actor == 'dependabot[bot]')
```

## Benefits
- ✅ Dependabot PRs now run full CI pipeline (formatting, linting, testing)
- ✅ Auto-approval after all checks pass
- ✅ Auto-merge with squash method
- ✅ Maintains same quality gates as manual PRs
- ✅ Enables seamless automated dependency management

## Testing
- ✅ Pre-commit hooks pass
- ✅ YAML syntax validated
- ✅ Both auto-approve and auto-merge jobs updated consistently

This completes the Dependabot automation setup from issue #19.

🤖 Generated with [Claude Code](https://claude.ai/code)