### PR TITLE
Potential fix for code scanning alert no. 1: Unused local variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -301,12 +301,10 @@ class ChatbotManager:
                                     session_id=session_id,
                                 )
                                 # Get the newly created session
-                                existing_session = (
-                                    await runner.session_service.get_session(
-                                        app_name=agent_name,
-                                        user_id=user_id,
-                                        session_id=session_id,
-                                    )
+                                await runner.session_service.get_session(
+                                    app_name=agent_name,
+                                    user_id=user_id,
+                                    session_id=session_id,
                                 )
                             except Exception as create_error:
                                 logger.error(


### PR DESCRIPTION
Potential fix for [https://github.com/davidasnider/home-agent-suite/security/code-scanning/1](https://github.com/davidasnider/home-agent-suite/security/code-scanning/1)

To fix the problem, we should remove the unused assignment to `existing_session` on line 304. If the call to `runner.session_service.get_session(...)` is needed for its side effects, we should replace the assignment with a bare `await` statement. Otherwise, we can simply remove the line. Since the code pattern is to fetch the session after creating it, it is likely that the call is needed, so the best fix is to replace the assignment with `await runner.session_service.get_session(...)`. Only the relevant line in `app.py` needs to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
